### PR TITLE
Fix 'name' field lengths to avoid truncation when loaded with datafixture data

### DIFF
--- a/Entity/Contact/Country.php
+++ b/Entity/Contact/Country.php
@@ -28,7 +28,7 @@ class Country extends AbstractEntity implements CountryInterface
     /**
      * @var string $name
      *
-     * @ORM\Column(name="name", type="string", length=30)
+     * @ORM\Column(name="name", type="string", length=60)
      */
     protected $name;
 

--- a/Entity/Contact/Region.php
+++ b/Entity/Contact/Region.php
@@ -27,7 +27,7 @@ class Region extends AbstractEntity implements RegionInterface
     /**
      * @var string $name
      *
-     * @ORM\Column(name="name", type="string", length=30)
+     * @ORM\Column(name="name", type="string", length=60)
      */
     protected $name;
 


### PR DESCRIPTION
MySQL silently truncates, but Postgres errors out when trying to load the datafixtures. I dont think this will cause any impact, though generating a migration after this change my drop and re-add the column.